### PR TITLE
Replace select_cols with simpler sub_slice.into plus some reformatting

### DIFF
--- a/src/learning/nnet/mod.rs
+++ b/src/learning/nnet/mod.rs
@@ -217,9 +217,9 @@ impl<T, A> NeuralNet<T, A>
     /// net.add_layers(linear_sig);
     /// ```
     pub fn add_layers<'a, U>(&'a mut self, layers: U) -> &'a mut NeuralNet<T, A>
-    	where U: IntoIterator<Item = Box<NetLayer>> {
-    		self.base.add_layers(layers);
-    		self
+        where U: IntoIterator<Item = Box<NetLayer>> {
+            self.base.add_layers(layers);
+            self
     }
 
     /// Gets matrix of weights between specified layer and forward layer.
@@ -247,7 +247,7 @@ impl<T, A> NeuralNet<T, A>
 
 /// Base Neural Network struct
 ///
-/// This struct cannot be instantianated and is used internally only.
+/// This struct cannot be instantiated and is used internally only.
 #[derive(Debug)]
 pub struct BaseNeuralNet<T: Criterion> {
     layers: Vec<Box<NetLayer>>,
@@ -299,11 +299,12 @@ impl<T: Criterion> BaseNeuralNet<T> {
 
     /// Adds multiple layers to the end of the network
     fn add_layers<'a, U>(&'a mut self, layers: U) -> &'a mut BaseNeuralNet<T>
-    	where U: IntoIterator<Item = Box<NetLayer>> {
-    		for layer in layers {
-    			self.add(layer);
-    		}
-    		self
+        where U: IntoIterator<Item = Box<NetLayer>> 
+    {
+        for layer in layers {
+            self.add(layer);
+        }
+        self
     }
 
     /// Gets matrix of weights for the specified layer for the weights.
@@ -311,17 +312,11 @@ impl<T: Criterion> BaseNeuralNet<T> {
         debug_assert!(idx < self.layers.len());
 
         // Check that the weights are the right size.
-        let mut full_size = 0usize;
-        for l in &self.layers {
-            full_size += l.num_params();
-        }
+        let full_size: usize = self.layers.iter().map(|l| l.num_params()).sum();
 
         debug_assert_eq!(full_size, weights.len());
 
-        let mut start = 0usize;
-        for l in &self.layers[..idx] {
-            start += l.num_params();
-        } 
+        let start: usize = self.layers.iter().take(idx).map(|l| l.num_params()).sum();
 
         let shape = self.layers[idx].param_shape();
         unsafe {
@@ -361,9 +356,9 @@ impl<T: Criterion> BaseNeuralNet<T> {
             };
 
             let output = if i == 0 {
-            	layer.forward(inputs, slice).unwrap()
+                layer.forward(inputs, slice).unwrap()
             } else {
-            	layer.forward(activations.last().unwrap(), slice).unwrap()
+                layer.forward(activations.last().unwrap(), slice).unwrap()
             };
 
             activations.push(output);
@@ -404,7 +399,7 @@ impl<T: Criterion> BaseNeuralNet<T> {
 
     /// Forward propagation of the model weights to get the outputs.
     fn forward_prop(&self, inputs: &Matrix<f64>) -> LearningResult<Matrix<f64>> {
-        if self.layers.len() == 0 {
+        if self.layers.is_empty() {
             return Ok(inputs.clone());
         }
 

--- a/src/learning/nnet/net_layer.rs
+++ b/src/learning/nnet/net_layer.rs
@@ -15,26 +15,26 @@ use std::fmt::Debug;
 
 /// Trait for neural net layers
 pub trait NetLayer : Debug {
-	/// The result of propogating data forward through this layer
-	fn forward(&self, input: &Matrix<f64>, params: MatrixSlice<f64>) -> LearningResult<Matrix<f64>>;
+    /// The result of propogating data forward through this layer
+    fn forward(&self, input: &Matrix<f64>, params: MatrixSlice<f64>) -> LearningResult<Matrix<f64>>;
 
-	/// The gradient of the output of this layer with respect to its input
-	fn back_input(&self, out_grad: &Matrix<f64>, input: &Matrix<f64>, params: MatrixSlice<f64>) -> Matrix<f64>;
-	
-	/// The gradient of the output of this layer with respect to its parameters
-	fn back_params(&self, out_grad: &Matrix<f64>, input: &Matrix<f64>, params: MatrixSlice<f64>) -> Matrix<f64>;
+    /// The gradient of the output of this layer with respect to its input
+    fn back_input(&self, out_grad: &Matrix<f64>, input: &Matrix<f64>, params: MatrixSlice<f64>) -> Matrix<f64>;
+    
+    /// The gradient of the output of this layer with respect to its parameters
+    fn back_params(&self, out_grad: &Matrix<f64>, input: &Matrix<f64>, params: MatrixSlice<f64>) -> Matrix<f64>;
 
-	/// The default value of the parameters of this layer before training
-	fn default_params(&self) -> Vec<f64>;
+    /// The default value of the parameters of this layer before training
+    fn default_params(&self) -> Vec<f64>;
 
-	/// The shape of the parameters used by this layer
-	fn param_shape(&self) -> (usize, usize);
+    /// The shape of the parameters used by this layer
+    fn param_shape(&self) -> (usize, usize);
 
-	/// The number of parameters used by this layer
-	fn num_params(&self) -> usize {
-		let shape = self.param_shape();
-		shape.0 * shape.1
-	}
+    /// The number of parameters used by this layer
+    fn num_params(&self) -> usize {
+        let shape = self.param_shape();
+        shape.0 * shape.1
+    }
 }
 
 /// Linear network layer
@@ -44,115 +44,116 @@ pub trait NetLayer : Debug {
 /// The parameters are a matrix of weights of size I x O
 /// where O is the dimensionality of the output and I the dimensionality of the input
 #[derive(Debug, Clone, Copy)]
-pub struct Linear {
-	/// The number of dimensions of the input
-	input_size: usize,
-	/// The number of dimensions of the output
-	output_size: usize,
-	/// Whether or not to include a bias term
-	has_bias: bool,
+pub struct Linear { 
+    /// The number of dimensions of the input
+    input_size: usize,
+    /// The number of dimensions of the output
+    output_size: usize,
+    /// Whether or not to include a bias term
+    has_bias: bool,
 }
 
 impl Linear {
-	/// Construct a new Linear layer
-	pub fn new(input_size: usize, output_size: usize) -> Linear {
-		Linear {
-			input_size: input_size + 1, 
-			output_size: output_size,
-			has_bias: true
-		}
-	}
+    /// Construct a new Linear layer
+    pub fn new(input_size: usize, output_size: usize) -> Linear {
+        Linear {
+            input_size: input_size + 1, 
+            output_size: output_size,
+            has_bias: true
+        }
+    }
 
-	/// Construct a Linear layer with a bias term
-	pub fn without_bias(input_size: usize, output_size: usize) -> Linear {
-		Linear {
-			input_size: input_size, 
-			output_size: output_size,
-			has_bias: false
-		}
-	}
+    /// Construct a Linear layer with a bias term
+    pub fn without_bias(input_size: usize, output_size: usize) -> Linear {
+        Linear {
+            input_size: input_size, 
+            output_size: output_size,
+            has_bias: false
+        }
+    }
 }
 
 impl NetLayer for Linear {
-	/// Computes a matrix product
-	///
-	/// input should have dimensions N x I
-	/// where N is the number of samples and I is the dimensionality of the input
-	fn forward(&self, input: &Matrix<f64>, params: MatrixSlice<f64>) -> LearningResult<Matrix<f64>> {
-		if self.has_bias {
-			if input.cols()+1 != params.rows() {
-				Err(Error::new(ErrorKind::InvalidData, "The input had the wrong number of columns"))
-			} else {
-				Ok(&input.hcat(&Matrix::ones(input.rows(), 1)) * &params)
-			}
-		} else {
-			if input.cols() != params.rows() {
-				Err(Error::new(ErrorKind::InvalidData, "The input had the wrong number of columns"))
-			} else {
-				Ok(input * &params)
-			}
-		}
-	}
+    /// Computes a matrix product
+    ///
+    /// input should have dimensions N x I
+    /// where N is the number of samples and I is the dimensionality of the input
+    fn forward(&self, input: &Matrix<f64>, params: MatrixSlice<f64>) -> LearningResult<Matrix<f64>> {
+        if self.has_bias {
+            if input.cols()+1 != params.rows() {
+                Err(Error::new(ErrorKind::InvalidData, "The input had the wrong number of columns"))
+            } else {
+                Ok(&input.hcat(&Matrix::ones(input.rows(), 1)) * &params)
+            }
+        } else {
+            if input.cols() != params.rows() {
+                Err(Error::new(ErrorKind::InvalidData, "The input had the wrong number of columns"))
+            } else {
+                Ok(input * &params)
+            }
+        }
+    }
 
-	fn back_input(&self, out_grad: &Matrix<f64>, _: &Matrix<f64>, params: MatrixSlice<f64>) -> Matrix<f64> {
-		debug_assert_eq!(out_grad.cols(), params.cols());
-		let gradient = out_grad * &params.transpose();
-		if self.has_bias {
-			let columns: Vec<_> = (0..gradient.cols()-1).collect();
-			gradient.select_cols(&columns)
-		} else {
-			gradient
-		}
-	}
-	
-	fn back_params(&self, out_grad: &Matrix<f64>, input: &Matrix<f64>, _: MatrixSlice<f64>) -> Matrix<f64> {
-		debug_assert_eq!(input.rows(), out_grad.rows());
-		if self.has_bias {
-			&input.hcat(&Matrix::ones(input.rows(), 1)).transpose() * out_grad
-		} else {
-			&input.transpose() * out_grad
-		}
-	}
+    fn back_input(&self, out_grad: &Matrix<f64>, _: &Matrix<f64>, params: MatrixSlice<f64>) -> Matrix<f64> {
+        debug_assert_eq!(out_grad.cols(), params.cols());
+        let gradient = out_grad * &params.transpose();
+        if self.has_bias {
+            let rows = gradient.rows();
+            let cols = gradient.cols() - 1;
+            gradient.sub_slice([0, 0], rows, cols).into() 
+        } else {
+            gradient
+        }
+    }
+    
+    fn back_params(&self, out_grad: &Matrix<f64>, input: &Matrix<f64>, _: MatrixSlice<f64>) -> Matrix<f64> {
+        debug_assert_eq!(input.rows(), out_grad.rows());
+        if self.has_bias {
+            &input.hcat(&Matrix::ones(input.rows(), 1)).transpose() * out_grad
+        } else {
+            &input.transpose() * out_grad
+        }
+    }
 
-	/// Initializes weights using Xavier initialization
-	///
-	/// weights drawn from gaussian distribution with 0 mean and variance 2/(input_size+output_size)
-	fn default_params(&self) -> Vec<f64> {
-		let mut distro = Normal::new(0.0, (2.0/(self.input_size+self.output_size) as f64).sqrt());
-		let mut rng = thread_rng();
+    /// Initializes weights using Xavier initialization
+    ///
+    /// weights drawn from gaussian distribution with 0 mean and variance 2/(input_size+output_size)
+    fn default_params(&self) -> Vec<f64> {
+        let mut distro = Normal::new(0.0, (2.0/(self.input_size+self.output_size) as f64).sqrt());
+        let mut rng = thread_rng();
 
-		(0..self.input_size*self.output_size).map(|_| distro.sample(&mut rng))
-											 .collect()
-	}
+        (0..self.input_size*self.output_size).map(|_| distro.sample(&mut rng))
+                                             .collect()
+    }
 
-	fn param_shape(&self) -> (usize, usize) {
-		(self.input_size, self.output_size)
-	}
+    fn param_shape(&self) -> (usize, usize) {
+        (self.input_size, self.output_size)
+    }
 }
 
 impl<T: ActivationFunc + Debug> NetLayer for T {
-	/// Applys the activation function to each element of the input
-	fn forward(&self, input: &Matrix<f64>, _: MatrixSlice<f64>) -> LearningResult<Matrix<f64>> {
-		Ok(input.clone().apply(&T::func))
-	}
+    /// Applys the activation function to each element of the input
+    fn forward(&self, input: &Matrix<f64>, _: MatrixSlice<f64>) -> LearningResult<Matrix<f64>> {
+        Ok(input.clone().apply(&T::func))
+    }
 
-	fn back_input(&self, out_grad: &Matrix<f64>, input: &Matrix<f64>, _: MatrixSlice<f64>) -> Matrix<f64> {
-		let mut in_grad = input.clone();
-		utils::in_place_vec_bin_op(in_grad.mut_data(), out_grad.data(), |x, &y| {
+    fn back_input(&self, out_grad: &Matrix<f64>, input: &Matrix<f64>, _: MatrixSlice<f64>) -> Matrix<f64> {
+        let mut in_grad = input.clone();
+        utils::in_place_vec_bin_op(in_grad.mut_data(), out_grad.data(), |x, &y| {
             *x = T::func_grad(*x) * y
         });
-		in_grad
-	}
-	
-	fn back_params(&self, _: &Matrix<f64>, _: &Matrix<f64>, _: MatrixSlice<f64>) -> Matrix<f64> {
-		Matrix::new(0, 0, Vec::new())
-	}
+        in_grad
+    }
+    
+    fn back_params(&self, _: &Matrix<f64>, _: &Matrix<f64>, _: MatrixSlice<f64>) -> Matrix<f64> {
+        Matrix::new(0, 0, Vec::new())
+    }
 
-	fn default_params(&self) -> Vec<f64> {
-		Vec::new()
-	}
+    fn default_params(&self) -> Vec<f64> {
+        Vec::new()
+    }
 
-	fn param_shape(&self) -> (usize, usize) {
-		(0, 0)
-	}
+    fn param_shape(&self) -> (usize, usize) {
+        (0, 0)
+    }
 }


### PR DESCRIPTION
This speeds thing a little, but doesn't get as fast as master. Apart for the retabs, the most relevant line is this one:
https://github.com/NivenT/rusty-machine/compare/master...tafia:pr126_modif?expand=1#diff-c540db215074ac211598380ba6b7e977R103

Instead of `select_cols` (not really efficient)

``` rust
let columns: Vec<_> = (0..gradient.cols()-1).collect();
gradient.select_cols(&columns)
```

Use `sub_slice`:

``` rust
let rows = gradient.rows();
let cols = gradient.cols() - 1;
gradient.sub_slice([0, 0], rows, cols).into() 
```

Benches:

```
master
test examples::nnet::nnet_and_gate_predict         ... bench:       1,351 ns/iter (+/- 36)
test examples::nnet::nnet_and_gate_train           ... bench: 105,611,081 ns/iter (+/- 438,629)

pr126
test examples::nnet::nnet_and_gate_predict         ... bench:       1,382 ns/iter (+/- 58)
test examples::nnet::nnet_and_gate_train           ... bench: 129,653,388 ns/iter (+/- 492,015)

with this pr
test examples::nnet::nnet_and_gate_predict         ... bench:       1,370 ns/iter (+/- 24)
test examples::nnet::nnet_and_gate_train           ... bench: 117,295,693 ns/iter (+/- 679,285)
```
