### PR TITLE
extend_from_slice instead of append

### DIFF
--- a/src/learning/nnet/mod.rs
+++ b/src/learning/nnet/mod.rs
@@ -292,7 +292,7 @@ impl<T: Criterion> BaseNeuralNet<T> {
 
     /// Adds the specified layer to the end of the network
     fn add<'a>(&'a mut self, layer: Box<NetLayer>) -> &'a mut BaseNeuralNet<T> {
-        self.weights.append(&mut layer.default_params());
+        self.weights.extend_from_slice(&layer.default_params());
         self.layers.push(layer);
         self
     }


### PR DESCRIPTION
Tiny optimization ...

```
before
test examples::nnet::nnet_and_gate_train           ... bench: 114,799,087 ns/iter (+/- 2,985,145)

after
test examples::nnet::nnet_and_gate_train           ... bench: 112,627,669 ns/iter (+/- 523,945)
```
